### PR TITLE
Fix default port not working

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,7 +242,15 @@ async def handle_sockets(websocket, path):
     number_of_sockets -= 1
 
 print('Starting server...')
-start_server = websockets.serve(handle_sockets, '0.0.0.0', int(os.environ['PORT']) or 5000)
+
+port = 5000
+
+try:
+    port = os.environ['PORT']
+except:
+    pass
+
+start_server = websockets.serve(handle_sockets, '0.0.0.0', int(port))
 
 asyncio.get_event_loop().run_until_complete(start_server)
 asyncio.get_event_loop().run_forever()


### PR DESCRIPTION
The default port wasn't working for me. It was failing cause it couldn't find the PORT key in the environ dict.